### PR TITLE
Add PocketBaseUML

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ List of tools that simplify SvelteKit DX further
 - [Flowbite](https://github.com/edde746/flowbite-svelte-but-better) - Clone of flowbite-react but for Svelte without the jank of flowbite-svelte
 - [Wordex](https://wordex.app/about) - Wordex clone built with SvelteKit
 - [LearnAwesome](https://github.com/learn-awesome/learndb) - Curated learning resources with topics, formats, difficulty levels, expert reviews and metadata tags
+- [PocketBaseUML](https://pocketbase-uml.github.io/) - A free, open-source UML diagram generator for PocketBase 
 - [Other Awesome Svelte-kit Projects](https://github.com/janosh/awesome-svelte-kit)
 
 ### Websites/Apps 


### PR DESCRIPTION
Hey, I'm the author of [tRPC-SvelteKit](https://icflorescu.github.io/trpc-sveltekit/) and [PocketBaseUML](https://pocketbase-uml.github.io/). I noticed that tRPC-SvelteKit is already in the list, so I thought I should add the latter as well, for the benefit of the community:

[![PocketBaseUML](https://user-images.githubusercontent.com/581999/226114639-f043c845-edde-4b8b-b89c-d618bb4521bd.png)](https://pocketbase-uml.github.io)

Thanks a lot for keeping this list and for accepting the PR!